### PR TITLE
README: `scaffold` to `exampleSite`, see 811e0c608

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cd classic/themes
 git clone git@github.com:goodroot/hugo-classic.git
 ```
 
-5: Copy the contents of the `scaffold` directory into {dir}/classic.
+5: Copy the contents of the `exampleSite` directory into {dir}/classic.
 
 6: Enjoy and customize to your hearts content!
 


### PR DESCRIPTION
The `scaffold` dir got renamed to `exampleSite` in 811e0c608, but the readme was not updated. This updates the readme.