### PR TITLE
Lowercase link destination for categories and tags

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -5,7 +5,7 @@
 <ul class="terms">
   {{ range $key, $value := .Data.Terms }}
   <li>
-    <a href="{{ (print "/" $.Data.Plural "/" $key) | relURL }}">
+    <a href="{{ (print "/" $.Data.Plural "/" (lower $key)) | relURL }}">
       {{ $key }}
     </a>
     ({{ len $value }})


### PR DESCRIPTION
without the lowercase $key, the links end up as 404 errors for me.
using hugo v0.30.2 and the latest hugo-classic theme