### PR TITLE
Add ability to import custom CSS files without overwriting templates

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -29,3 +29,4 @@ footnotereturnlinkcontents = "↩"
 [params]
     description = "A simple, minimal blog for those who love text."
     footer = "Open-Source | [Github](https://github.com/goodroot/hugo-classic) | [Twitter](https://twitter.com/thegoodroot)"
+    custom_css = ["css/theme-override.css"]

--- a/exampleSite/static/css/theme-override.css
+++ b/exampleSite/static/css/theme-override.css
@@ -1,0 +1,1 @@
+footer { font-size: 90%; font-family: monospace; }

--- a/layouts/partials/foot_custom.html
+++ b/layouts/partials/foot_custom.html
@@ -1,2 +1,25 @@
-<!-- Automagically centers images. -->
-<script async src="//yihui.name/js/center-img.js"></script>
+<!-- Automagically centers images. Original Author Yihui Xie: https://yihui.name -->
+<script>
+(function() {
+  function center_el(tagName) {
+    var tags = document.getElementsByTagName(tagName), i, tag;
+    for (i = 0; i < tags.length; i++) {
+      tag = tags[i];
+      var parent = tag.parentElement;
+      // center an image if it is the only element of its parent
+      if (parent.childNodes.length === 1) {
+        // if there is a link on image, check grandparent
+        if (parent.nodeName === 'A') {
+          parent = parent.parentElement;
+          if (parent.childNodes.length != 1) continue;
+        }
+        if (parent.nodeName === 'P') parent.style.textAlign = 'center';
+      }
+    }
+  }
+  var tagNames = ['img', 'embed', 'object'];
+  for (var i = 0; i < tagNames.length; i++) {
+    center_el(tagNames[i]);
+  }
+})();
+</script>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -6,6 +6,9 @@
     <title>{{ .Title }} | {{ .Site.Title }}</title>
     <link rel="stylesheet" href="{{ "/css/style.css" | relURL }}" />
     <link rel="stylesheet" href="{{ "/css/fonts.css" | relURL }}" />
+    {{ range .Site.Params.custom_css -}}
+    <link rel="stylesheet" href="{{ . | absURL }}">
+    {{- end }}
     {{ partial "head_custom.html" . }}
   </head>
 


### PR DESCRIPTION
Made the change suggested by digitalcraftsman:
https://discourse.gohugo.io/t/how-to-override-css-classes-with-hugo/3033/4

With this, user can specify arbitrary number of overriding CSS files to be imported in the header, without having to override the header.