### PR TITLE
Fix tags and categories

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -9,7 +9,7 @@
 
   <ul>
      {{ $pages := .Pages }}
-     {{ if .IsHome }}{{ $pages := .Site.RegularPages }}{{ end }}
+     {{ if .IsHome }}{{ $pages = .Site.RegularPages }}{{ end }}
      {{ range (where $pages "Section" "!=" "") }}
      <li>
        <span class="date">{{ .Date.Format "2006/01/02" }}</span>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -8,7 +8,7 @@
   {{ .Content }}
 
   <ul>
-     {{ $pages := .Site.RegularPages }}
+     {{ $pages := .Pages }}
      {{ if .IsHome }}{{ $pages := .Site.RegularPages }}{{ end }}
      {{ range (where $pages "Section" "!=" "") }}
      <li>


### PR DESCRIPTION
There was an issue where viewing tags or categories would show ALL posts, not just those for the certain tag or category.

This should correct that.